### PR TITLE
Expand role checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Assumer will assume-role on a target account and generate temporary API keys for
 
 Assumer requires a Ruby version >= 2.1
 
+Install with `gem install assumer`
+
 ### Build from Source ###
 
 1. Clone the repository
@@ -20,7 +22,7 @@ Assumer requires a Ruby version >= 2.1
 1. Build and install the gem
   * `gem build assumer.gemspec`
 1. Install the gem
-  * `gem install assumer-0.4.0.gem`
+  * `gem install assumer-0.4.1.gem`
 
 ## Usage ##
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,5 +1,9 @@
 # Assumer Change Log #
 
+## Version 0.4.1 ##
+
+* Brought the role validation regex in-line with the one used by Amazon.
+
 ## Version 0.4.0 ##
 
 * First public release

--- a/source/assumer.gemspec
+++ b/source/assumer.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables.reject! { |f| f == '.rubocop.yml' }
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/source/assumer.gemspec
+++ b/source/assumer.gemspec
@@ -13,14 +13,6 @@ Gem::Specification.new do |spec|
   spec.description   = 'Allows for single or double-jumps through AWS accounts in order to assume a role in a target account'
   spec.homepage      = 'https://github.com/devsecops/assumer'
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    fail 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/source/exe/assumer
+++ b/source/exe/assumer
@@ -39,9 +39,6 @@ warn "MFA Serial Number:   #{mfa_serial_number}" if DEBUG_FLAG
 warn "Control Plane Role:  #{control_plane_role}" if DEBUG_FLAG
 warn "Target Account Role: #{target_account_role}" if DEBUG_FLAG
 
-Trollop::die :target_role, 'Invalid target role' unless target_account_role =~ %r{arn:aws:iam::\d{12}:role/[\w-]+?/[\w-]+}
-Trollop::die :control_rule, 'Invalid control role' unless control_plane_role =~ %r{arn:aws:iam::\d{12}:role/[\w-]+?/[\w-]+}
-
 puts <<EOF
 #{parsed_options[:username]} is assuming
 #{target_account_role}

--- a/source/lib/assumer.rb
+++ b/source/lib/assumer.rb
@@ -28,10 +28,11 @@ module Assumer
       @role = verify_role(role: role)
       # If we are being passed credentials, it's an Assumer instance, and we can
       # get the creds from it.  Otherwise, establish an STS connection
-      @sts_client = establish_sts(region: @region,
-                                  passed_credentials: credentials,
-                                  credentials_profile: profile
-                                 )
+      @sts_client = establish_sts(
+        region: @region,
+        passed_credentials: credentials,
+        credentials_profile: profile
+      )
       @serial_number = serial_number # ARN for the user's MFA serial number
 
       opts = {
@@ -57,7 +58,7 @@ module Assumer
     # @return [String] The ARN of a valid role
     # @raise [AssumerError] If the ARN is invalid, an exception is raised
     def verify_role(role:)
-      raise AssumerError, "Invalid ARN for role #{role}" if role =~ AWS_ROLE_REGEX
+      raise AssumerError, "Invalid ARN for role #{role}" unless role =~ AWS_ROLE_REGEX
       role
     end
 

--- a/source/lib/assumer/version.rb
+++ b/source/lib/assumer/version.rb
@@ -1,3 +1,3 @@
 module Assumer
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
The previous regex allowed a subset of valid AWS role names.  The new regex is the same one AWS uses, making it more permissive but also more correct.

The gemspec file has been modified to allow for pushes to RubyGems.org
